### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "vue": "^3.3.8",
     "vue-chartjs": "^5.2.0",
     "vue-router": "^4.2.5",
-    "vue-toastification": "^2.0.0-rc.5"
+    "vue-toastification": "^2.0.0-rc.5",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.3",

--- a/server.js
+++ b/server.js
@@ -8,9 +8,19 @@ import path from 'path';
 import dotenv from 'dotenv';
 import fs from 'fs';
 import Stripe from 'stripe';
+import rateLimit from 'express-rate-limit';
 
 // Load environment variables
 dotenv.config();
+
+// Set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+// Apply rate limiter to all requests
+app.use(limiter);
 
 // ES module compatibility for __dirname
 const __filename = fileURLToPath(import.meta.url);


### PR DESCRIPTION
Potential fix for [https://github.com/deeyes23/Amal2/security/code-scanning/2](https://github.com/deeyes23/Amal2/security/code-scanning/2)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` middleware. This middleware allows us to limit the number of requests a client can make to the server within a specified time window. We will set up a rate limiter and apply it to all requests to ensure that the server is protected from potential denial-of-service attacks.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `server.js` file.
3. Set up a rate limiter with a reasonable configuration (e.g., 100 requests per 15 minutes).
4. Apply the rate limiter to all requests using `app.use`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
